### PR TITLE
Gitで除外するファイルについて.gitignoreに追記

### DIFF
--- a/first_app/.gitignore
+++ b/first_app/.gitignore
@@ -14,3 +14,7 @@
 # Ignore all logfiles and tempfiles.
 /log/*.log
 /tmp
+vendor/bundle
+
+.rvmrc
+.ruby-version

--- a/first_app/Gemfile.lock
+++ b/first_app/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (~> 2.8)
+    sqlite3 (1.3.8)
     sqlite3 (1.3.8-x86-mingw32)
     thor (0.19.1)
     thread_safe (0.3.4)
@@ -103,6 +104,7 @@ GEM
       multi_json (~> 1.0, >= 1.0.2)
 
 PLATFORMS
+  ruby
   x86-mingw32
 
 DEPENDENCIES


### PR DESCRIPTION
個人の開発環境等に依存しそうなファイルを幾つか.gitignoreに追記しました。
- .rvmrc
- .ruby-version

rvmやrbenvという複数のrubyのバージョンをインストール & 管理できるツールの設定ファイルです。
(macやlinuxでの開発者でこれらのツールを使っているかもしれません。)
- vendor/bundle

`bundle install` する時に`bundle install --path vendor/bundle`とgemライブラリのインストール先を指定することが多いです。(Virtual Box等で専用の開発環境を構築した場合はこの限りでないかもしれません。)
インストールしたgemそのものは管理から外しておく方が良いでしょう。
